### PR TITLE
Fix parentheses on functions-lambdas-are-nameless-functions

### DIFF
--- a/koans/functions.el
+++ b/koans/functions.el
@@ -139,7 +139,7 @@ arguments (possibly none) are collected into a list."
  elisp-koans/functions-lambdas-are-nameless-functions ()
  "A `lambda' form defines a function, but with no name.  It is possible
 to execute that function immediately, or put it somewhere for later use."
- (should (eq ___ ((lambda (a b)) (+ a b)) 10 9))
+ (should (eq ___ ((lambda (a b) (+ a b)) 10 9)))
  (let ((my-function))
    (setf my-function (lambda (a b) (* a b)))
    (should (eq ___ (funcall my-function 11 9))))
@@ -147,7 +147,7 @@ to execute that function immediately, or put it somewhere for later use."
    (push (lambda (a b) (+ a b)) list-of-functions)
    (push (lambda (a b) (* a b)) list-of-functions)
    (push (lambda (a b) (- a b)) list-of-functions)
-   (should (equal ___ (funcall (second list-of-functions)) 2 33))))
+   (should (equal ___ (funcall (second list-of-functions) 2 33)))))
 
 
 (elisp-koans/deftest


### PR DESCRIPTION
Hi @jtmoulia ,

I noticed two small issues when I was solving `functions.el`.
- We have an empty lambda function without a body on Line 142.
- We're invoking the `funcall` function without the arguments on Line 150.

This PR should solve it. :)
Let me know if you need anything else.
