### PR TITLE
Seems like dash.el is required.

### DIFF
--- a/elisp-koans.el
+++ b/elisp-koans.el
@@ -13,6 +13,7 @@
 ;; -*- lexical-binding: t; -*-
 
 (require 'cl-lib)
+(require 'dash)
 
 (defconst elisp-koans--blanks '(__ ___ ____))
 (defconst elisp-koans--groups-directory (expand-file-name "koans/")


### PR DESCRIPTION
I'm not very familiar with the dash package and it's history to know if it's built-in.  But I think it is required to pick up the `-flatten` function.